### PR TITLE
test fix and cache module patches

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,6 +134,11 @@ If this seems a little hacky, it's because I wanted to make it easy to use whate
   converted to absolute URLs while being processed. Any local absolute urls (those
   starting with a '/') are left alone.
 
+``COMPRESS_CACHE_BACKEND`` default: ``CACHE_BACKEND``
+  The backend to use for caching, in case you want to use a different cache
+  backend for compressor. Defaults to the ``CACHE_BACKEND`` setting.
+
+
 
 Notes
 *****

--- a/compressor/cache.py
+++ b/compressor/cache.py
@@ -1,0 +1,4 @@
+from django.core.cache import get_cache
+from compressor.conf import settings
+
+cache = get_cache(settings.CACHE_BACKEND)

--- a/compressor/conf/settings.py
+++ b/compressor/conf/settings.py
@@ -14,3 +14,5 @@ COMPILER_FORMATS = getattr(settings, 'COMPILER_FORMATS', {})
 
 if ABSOLUTE_CSS_URLS and 'compressor.filters.css_default.CssAbsoluteFilter' not in COMPRESS_CSS_FILTERS:
     COMPRESS_CSS_FILTERS.insert(0, 'compressor.filters.css_default.CssAbsoluteFilter')
+
+CACHE_BACKEND = getattr(settings, 'COMPRESS_CACHE_BACKEND', settings.CACHE_BACKEND)

--- a/compressor/filters/css_default.py
+++ b/compressor/filters/css_default.py
@@ -12,9 +12,9 @@ URL_PATTERN = re.compile(r'url\(([^\)]+)\)')
 class CssAbsoluteFilter(FilterBase):
     def input(self, filename=None, media_url=None, **kwargs):
         media_url = media_url or settings.MEDIA_URL
-        media_root = os.path.abspath(settings.MEDIA_ROOT)
+        media_root = os.path.realpath(settings.MEDIA_ROOT)
         if filename is not None:
-            filename = os.path.abspath(filename)
+            filename = os.path.realpath(filename)
         if not filename or not filename.startswith(media_root):
             return self.content
         self.media_path = filename[len(media_root):]

--- a/compressor/templatetags/compress.py
+++ b/compressor/templatetags/compress.py
@@ -1,5 +1,4 @@
 from django import template
-from django.core.cache import cache
 
 try:
     from django.contrib.sites.models import Site
@@ -8,6 +7,7 @@ except:
     DOMAIN = ''
     
 from compressor import CssCompressor, JsCompressor
+from compressor.cache import cache
 from compressor.conf import settings
 from time import sleep
 

--- a/compressor/tests.py
+++ b/compressor/tests.py
@@ -19,7 +19,7 @@ class BaseTestCase(TestCase):
     
     def setUp(self):
         self.old_settings = copy(settings.__dict__)
-        self.TEST_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "testing")
+        self.TEST_DIR = os.path.realpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "testing"))
         settings.MEDIA_ROOT = os.path.join(self.TEST_DIR, 'media')
         settings.MEDIA_URL = '/media/'
         settings.COMPRESS_CSS_FILTERS = ['compressor.filters.css_default.CssAbsoluteFilter']

--- a/compressor/tests.py
+++ b/compressor/tests.py
@@ -10,6 +10,7 @@ from django.test import TestCase
 from compressor import CssCompressor, JsCompressor, UncompressableFileError
 from compressor.conf import settings
 from compressor.utils import get_file_hash
+from django.core.cache.backends import dummy
 
 class BaseTestCase(TestCase):
     
@@ -31,6 +32,7 @@ class BaseTestCase(TestCase):
                 'arguments': '*.ccss'
             },
         }
+        settings.CACHE_BACKEND = "dummy://"
         
 
 class CompressorTestCase(BaseTestCase):
@@ -254,3 +256,8 @@ class TemplatetagTestCase(BaseTestCase):
         out = u'<script type="text/javascript" src="/media/CACHE/js/3f33b9146e12.js"></script>'
         self.assertEqual(out, self.render(template, context))
 
+
+class CacheBackendTestCase(BaseTestCase):
+    def test_correct_backend(self):
+        from compressor.cache import cache
+        self.assertEqual(cache.__class__, dummy.CacheClass)

--- a/compressor/utils.py
+++ b/compressor/utils.py
@@ -8,7 +8,7 @@ def get_hexdigest(plaintext):
     return sha_constructor(p).hexdigest()
 
 def get_file_hash(filename):
-    media_root = os.path.abspath(settings.MEDIA_ROOT)
+    media_root = os.path.realpath(settings.MEDIA_ROOT)
     if not filename.startswith(media_root):
         filename = os.path.join(media_root, filename)
     try:
@@ -16,4 +16,3 @@ def get_file_hash(filename):
         return get_hexdigest(str(int(mtime)))[:12]
     except OSError:
         return None
-    


### PR DESCRIPTION
Hi David,

I fixed a test case (believe it was a regression due to the os.path.realpath commit), and also pulled the CACHE_BACKEND feature from django_compressor (with test), and would love to have these included so I don't have to keep this fork.

The cache backend feature is essential for my use case because I'd like the default Django cache backend to use a shared cache of multiple memcached instances, but when running Django on multiple machines, django-css will find that the compressed file path is already in cache (placed by another Django instance on a different machine) and it won't bother to generated the media file locally causing a 404. Obviously this can be solved by some sort of NFS or using a storage backend that is distributed, but we intentionally do not want that.

Let me know if you have any questions or concerns.

.wil
