### PR TITLE
Fixes to media paths

### DIFF
--- a/compressor/__init__.py
+++ b/compressor/__init__.py
@@ -169,7 +169,7 @@ class Compressor(object):
         """
         if not settings.COMPRESS:
             return self.return_compiled_content(self.content)
-        url = "/".join((self.media_url.rstrip('/'), self.new_filepath))
+        url = "/".join((default_storage.base_url.rstrip('/'), self.new_filepath))
         self.save_file()
         context = getattr(self, 'extra_context', {})
         context['url'] = url

--- a/compressor/templatetags/compress.py
+++ b/compressor/templatetags/compress.py
@@ -21,8 +21,8 @@ class CompressorNode(template.Node):
 
     def render(self, context):
         content = self.nodelist.render(context)
-        if 'MEDIA_URL' in context:
-            media_url = context['MEDIA_URL']
+        if 'COMPRESS_URL' in context:
+            media_url = context['COMPRESS_URL']
         else:
             media_url = settings.MEDIA_URL
         if self.kind == 'css':


### PR DESCRIPTION
Some issues with the media paths came up when using django-css with Django 1.3 (beta). 
1. Since STATIC_URL is to be used in static urls picking up MEDIA_URL from template context causes problem (if they're not the same). This fix picks up COMPRESS_URL instead which doesn't clash with either of MEDIA_URL or STATIC_URL (and you can use {% with MEDIA_URL as COMPRESS_URL %} ).
2. A change so that the storage backend's base_url is used when composing urls.
