### PR TITLE
Remove os.path.realpath from Compressor.get_file

### DIFF
--- a/compressor/__init__.py
+++ b/compressor/__init__.py
@@ -64,7 +64,6 @@ class Compressor(object):
     def get_filename(self, url):
         if not url.startswith(self.media_url):
             raise UncompressableFileError('"%s" is not in COMPRESS_URL ("%s") and can not be compressed' % (url, self.media_url))
-        url = os.path.realpath(url)
         basename = url[len(self.media_url):]
         filename = os.path.join(settings.MEDIA_ROOT, basename)
         return os.path.realpath(filename)


### PR DESCRIPTION
get_file operates on urls, but os.path.realpath operates on file paths. Don't know why os.path.realpath is used in get_file.
