### PR TITLE
Encode File Content as UTF-8

### DIFF
--- a/compressor/__init__.py
+++ b/compressor/__init__.py
@@ -146,7 +146,7 @@ class Compressor(object):
     def save_file(self):
         if default_storage.exists(self.new_filepath):
             return False
-        default_storage.save(self.new_filepath, ContentFile(self.combined))
+        default_storage.save(self.new_filepath, ContentFile(self.combined.encode('utf-8')))
         return True
 
     def return_compiled_content(self, content):


### PR DESCRIPTION
The ContentFile Django class expects a byte string (see here http://docs.djangoproject.com/en/dev/ref/files/file/#the-contentfile-class for an example).

Previously django-css was passing it a unicode object, which sometimes happened to work but sometimes caused weird encoding issues.

This patch encodes the content as UTF-8 before passing it along to be saved.
